### PR TITLE
Fix bug in getting ROTATE_ANIMATION_EXPONENT with wrong key

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.0"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "com.sample"
         minSdkVersion 19
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -24,8 +24,8 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:24.2.1'
-    compile 'com.android.support:design:24.2.1'
+    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:design:25.1.0'
     testCompile 'junit:junit:4.12'
     compile project(path: ':flickabledialog')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.novoda:bintray-release:0.3.4'
     }
 }

--- a/flickabledialog/build.gradle
+++ b/flickabledialog/build.gradle
@@ -2,14 +2,14 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
     lintOptions {
         abortOnError false
     }
     defaultConfig {
         minSdkVersion 11
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
 
@@ -29,7 +29,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:24.2.1'
+    compile 'com.android.support:appcompat-v7:25.1.0'
     testCompile 'junit:junit:4.12'
     compile 'org.testng:testng:6.9.6'
     compile 'junit:junit:4.12'

--- a/flickabledialog/proguard-rules.pro
+++ b/flickabledialog/proguard-rules.pro
@@ -15,3 +15,5 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+-keepattributes InnerClasses

--- a/flickabledialog/src/main/java/com/tkurimura/flickabledialog/FlickableDialog.java
+++ b/flickabledialog/src/main/java/com/tkurimura/flickabledialog/FlickableDialog.java
@@ -124,7 +124,7 @@ public class FlickableDialog extends DialogFragment {
     @LayoutRes final int layoutResource = bundle.getInt(LAYOUT_RESOURCE_KEY);
 
     DISMISS_THRESHOLD = bundle.getFloat(DISMISS_THRESHOLD_KEY, DISMISS_THRESHOLD);
-    ROTATE_ANIMATION_EXPONENT = bundle.getFloat(DISMISS_THRESHOLD_KEY, ROTATE_ANIMATION_EXPONENT);
+    ROTATE_ANIMATION_EXPONENT = bundle.getFloat(ROTATE_ANIMATION_KEY, ROTATE_ANIMATION_EXPONENT);
     int backgroundColorResource = bundle.getInt(BACKGROUND_COLOR_RESOURCE_KEY, 0);
 
     final FrameLayout frameLayout = new FrameLayout(getContext());


### PR DESCRIPTION
Also:
* Added proguard rule “-keepattributes InnerClasses” to avoid “InnerClasses/anonymous inner class” warnings
* Updated compile SDK version to 25