### PR TITLE
Remove unnecessary manifest file

### DIFF
--- a/flickabledialog/src/main/AndroidManifest.xml
+++ b/flickabledialog/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.flickabledialog">
+</manifest>

--- a/flickabledialog/src/main/AndroidManifest.xml
+++ b/flickabledialog/src/main/AndroidManifest.xml
@@ -1,8 +1,0 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.flickabledialog">
-
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
-</manifest>


### PR DESCRIPTION
The original manifest looks like it overrides the following attributes:
```
android:allowBackup="true"
android:label="@string/app_name"
android:supportsRtl="true"
```

That isn't necessary nor correct is it?